### PR TITLE
Fix: Update Colab link to correct repository

### DIFF
--- a/memvid_colab_gpu.ipynb
+++ b/memvid_colab_gpu.ipynb
@@ -40,7 +40,7 @@
     "!nvidia-smi\n",
     "\n",
     "# Clone the repository\n",
-    "!git clone https://github.com/featuregraph/memvid.git\n",
+    "!git clone https://github.com/ChegeKenya/memvid.git\n",
     "%cd memvid\n",
     "\n",
     "# Install system dependencies\n",


### PR DESCRIPTION
The Colab notebook link was pointing to an incorrect repository, causing an error when trying to open it. This commit updates the link to point to the correct repository.

Output: